### PR TITLE
support for agnostic bash paths

### DIFF
--- a/send_slots/shell/send_slots.sh
+++ b/send_slots/shell/send_slots.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## CHANGE THESE TO SUIT YOUR POOL TO YOUR POOL ID AS ON THE EXPLORER
 MY_POOL_ID="XXXXXXXX"

--- a/send_slots/shell/send_slots_override.sh
+++ b/send_slots/shell/send_slots_override.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #MY_POOL_ID="<POOLID>"
 #MY_USER_ID="<USERID>" # on pooltool website get this from your account profile page

--- a/sendmytip/shell/sendmytip.sh
+++ b/sendmytip/shell/sendmytip.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## CHANGE THESE TO SUITE YOUR POOL
 # your pool id as on the explorer


### PR DESCRIPTION
This changes make it possible to use agnostic paths for ```bash``` which add support for non-FHS systems such as NixOS or OpenBSD.