### PR TITLE
Update leaderLogs.py (bugfix epoch arg) and getSigma (--next)

### DIFF
--- a/leaderLogs/getSigma.py
+++ b/leaderLogs/getSigma.py
@@ -6,6 +6,7 @@ from os import path
 parser = argparse.ArgumentParser(description="Calculate the sigma value of the specified pool. If you do not provide the path to a ledger file via the --ledger option then the script will look for a ledger.json file in the current directory")
 parser.add_argument('--pool-id', dest='id', help='the pool ID', required=True)
 parser.add_argument('--ledger', dest='ledger', default='ledger.json', help='the path to a current ledger-state JSON file')
+parser.add_argument('--next', action='store_true', help='if specified will provide sigma for the next epoch instead of the current epoch')
 
 args = parser.parse_args()
 
@@ -19,12 +20,18 @@ if not path.exists(ledger):
 
 with open(ledger) as f:
     ledger = json.load(f)
+    
+stakequery="_pstakeSet"
+stakeinfo="active"
+if args.next:
+  stakequery="_pstakeMark"
+  stakeinfo="next"
 
 blockstakedelegators={}
 blockstake={}
 bs={}
-print("building active stake")
-for item2 in ledger['esSnapshots']["_pstakeSet"]['_delegations']:
+print("building "+stakeinfo+" stake")
+for item2 in ledger['esSnapshots'][stakequery]['_delegations']:
     keyhashobj = []
     for itemsmall in item2:
         if 'key hash' in itemsmall:
@@ -36,7 +43,7 @@ for item2 in ledger['esSnapshots']["_pstakeSet"]['_delegations']:
     else:
         blockstakedelegators[poolid]=blockstakedelegators[poolid]+keyhashobj
 
-for item2 in ledger['esSnapshots']["_pstakeSet"]['_stake']:
+for item2 in ledger['esSnapshots'][stakequery]['_stake']:
     delegatorid = None
     for itemsmall in item2:
         if isinstance(itemsmall,int):

--- a/leaderLogs/leaderLogs.py
+++ b/leaderLogs/leaderLogs.py
@@ -24,8 +24,15 @@ parser.add_argument('--tz', dest='tz', default='America/Los_Angeles', help='the 
 
 args = parser.parse_args()
 
+epoch = args.epoch
+if epoch == None:
+   print("\033[94m[INFO]:\033[0m No epoch provided, using latest known epoch.") 
+   url=("https://epoch-api.crypto2099.io:2096/epoch/")
+else:
+   url=("https://epoch-api.crypto2099.io:2096/epoch/"+str(epoch))
+
 try:
-    page = urlopen("https://epoch-api.crypto2099.io:2096/epoch/")
+    page = urlopen(url)
     epoch_data = json.loads(page.read().decode("utf-8"))
 except:
     print("\033[1;31m[WARN]:\033[0m Unable to fetch data from the epoch API.")


### PR DESCRIPTION
Bugfix: Use the optional epoch parameter in the web query and provide a hint if it is not specified.
Issue: On epoch transition when this script is called before the web api has the data for the new epoch the output will display using the epoch from the command line but in fact not pass this epoch to the web query so the ouput is very misleading.