### PR TITLE
Update leaderLogs.py

### DIFF
--- a/leaderLogs/leaderLogs.py
+++ b/leaderLogs/leaderLogs.py
@@ -60,6 +60,8 @@ else:
 
 # Bindings are not avaliable so using ctypes to just force it in for now.
 libsodium = cdll.LoadLibrary("/usr/local/lib/libsodium.so")
+#MACOS users can use this and comment line above
+#libsodium = cdll.LoadLibrary("/usr/local/lib/libsodium.23.dylib")
 libsodium.sodium_init()
 
 # Hard code these for now.


### PR DESCRIPTION
Not sure how you want to incorporate this but for whoever wants to run this on MACOS the only difference is line 62
  libsodium.23.dylib instead of libsodium.so 

and ensure they installed the libsodium from https://github.com/input-output-hk/libsodium