### PR TITLE
Fix python3 pytz install cmd.

### DIFF
--- a/leaderLogs/README.md
+++ b/leaderLogs/README.md
@@ -49,7 +49,7 @@ This script requires the *pytz* extension for Python. You can make sure this is 
 on your system by running the following command:
 
 ```shell
-user@foo:~$ python3 pip -m install pytz
+user@foo:~$ python3 -m pip install pytz
 ```
 ### Arguments
 


### PR DESCRIPTION
'-m' flag for running python module as script should follow python3 command.