### PR TITLE
Introduce --porcelain flags to leaderlogs scripts

### DIFF
--- a/leaderLogs/getSigma.py
+++ b/leaderLogs/getSigma.py
@@ -39,7 +39,12 @@ bs={}
 if not args.porcelain:
     print("building "+stakeinfo+" stake")
 
-for item2 in ledger['esSnapshots'][stakequery]['_delegations']:
+if 'nesEs' in ledger:
+  ledger_set=ledger['nesEs']['esSnapshots'][stakequery]
+else:
+  ledger_set=ledger['esSnapshots'][stakequery]
+
+for item2 in ledger_set['_delegations']:
     keyhashobj = []
     for itemsmall in item2:
         if 'key hash' in itemsmall:
@@ -51,7 +56,7 @@ for item2 in ledger['esSnapshots'][stakequery]['_delegations']:
     else:
         blockstakedelegators[poolid]=blockstakedelegators[poolid]+keyhashobj
 
-for item2 in ledger['esSnapshots'][stakequery]['_stake']:
+for item2 in ledger_set['_stake']:
     delegatorid = None
     for itemsmall in item2:
         if isinstance(itemsmall,int):

--- a/leaderLogs/getSigma.py
+++ b/leaderLogs/getSigma.py
@@ -16,7 +16,7 @@ ledger = args.ledger
 if not path.exists(ledger):
     print("We tried but could not locate your ledger-state JSON file!")
     print("Use: \033[1;34mcardano-cli shelley query ledger-state --mainnet --out-file ledger.json\033[0m to export one!")
-    exit()
+    exit(1)
 
 with open(ledger) as f:
     ledger = json.load(f)

--- a/leaderLogs/leaderLogs.py
+++ b/leaderLogs/leaderLogs.py
@@ -60,9 +60,9 @@ def fetchEpochData(epoch):
 
     try:
         page = urlopen(url)
-        epoch_data = json.loads(page.read().decode("utf-8"))
+        return json.loads(page.read().decode("utf-8"))
     except:
-        print_safe("\033[1;31m[WARN]:\033[0m Unable to fetch data from the epoch API.")
+        print_safe("\033[1;31m[WARN]:\033[0m Unable to fetch data from the epoch API (" + str(e) +").")
         exit(1)
 
 try:
@@ -79,8 +79,8 @@ try:
     poolId = args.poolId
     sigma = args.sigma
     local_tz = pytz.timezone(args.tz)
-except:
-    print_safe("\033[1;31m[ERROR]:\033[0m One or more arguments are missing or invalid. Please try again.")
+except err:
+    print_safe("\033[1;31m[ERROR]:\033[0m One or more arguments are missing or invalid (" + str(e) +"). Please try again.")
     parser.format_help()
     parser.print_help()
     exit(1)

--- a/leaderLogs/leaderLogs.py
+++ b/leaderLogs/leaderLogs.py
@@ -47,7 +47,7 @@ def print_safe(*text):
         print(text)
 
 epochNeeded = args.epoch == None
-nonceNeeded = args.epoch-nonce == None
+nonceNeeded = args.eta0 == None
 dNeeded = args.d == None
 apiNeedeed = epochNeeded | nonceNeeded | dNeeded
 

--- a/leaderLogs/leaderLogs.py
+++ b/leaderLogs/leaderLogs.py
@@ -52,11 +52,12 @@ dNeeded = args.d == None
 apiNeedeed = epochNeeded | nonceNeeded | dNeeded
 
 def fetchEpochData(epoch):
+    api_url="https://api.crypto2099.io/v1/sigma/" + poolId + "/"
     if epoch == None:
         print_safe("\033[94m[INFO]:\033[0m No epoch provided, using latest known epoch.")
-        url=("https://epoch-api.crypto2099.io:2096/epoch/")
+        url=(api_url)
     else:
-        url=("https://epoch-api.crypto2099.io:2096/epoch/"+str(epoch))
+        url=(api_url + str(epoch))
 
     try:
         page = urlopen(url)
@@ -68,8 +69,8 @@ def fetchEpochData(epoch):
 try:
     if apiNeedeed:
         epoch_data = fetchEpochData(args.epoch)
-        epoch = epoch_data['number']
-        eta0 = epoch_data['eta0']
+        epoch = epoch_data['epoch']
+        eta0 = epoch_data['nonce']
         decentralizationParam = args.d or epoch_data['d']
     else:
         epoch = args.epoch


### PR DESCRIPTION
Introduce the `--porcelain` flag to `getSigma.py` and `leaderLogs.py`.

The porcelain flag can be used to produce json output instead of the unstructured human focused output of the tools. This should help with programmatic integration into other tools.